### PR TITLE
feat(binance): add sha256 check

### DIFF
--- a/src/data/binance/file.rs
+++ b/src/data/binance/file.rs
@@ -62,12 +62,16 @@ impl File {
     async fn checksum_matches(&self) -> Result<bool> {
         let bucket = Bucket::new().map_err(|e| anyhow!("Failed to create bucket: {}", e))?;
         let bucket_sha_string = bucket.read_object(&self.checksum.key).await?;
-        let bucket_sha = bucket_sha_string.split(' ').next().unwrap().to_lowercase();
-        let disk_sha = self.sha256_digest_lower().await?;
+        let bucket_sha = bucket_sha_string
+            .split(' ')
+            .next()
+            .unwrap()
+            .to_ascii_lowercase();
+        let disk_sha = self.sha256_digest().await?.to_ascii_lowercase();
         Ok(bucket_sha.eq(disk_sha.as_str()))
     }
 
-    async fn sha256_digest_lower(&self) -> Result<String> {
+    async fn sha256_digest(&self) -> Result<String> {
         // TODO: Refactor to utilities
         let input = fs::File::open(&self.path).await?;
         let mut reader = BufReader::new(input);

--- a/src/data/binance/file.rs
+++ b/src/data/binance/file.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use log::info;
 use s3::serde_types::Object;
 use sha2::{Digest, Sha256};
 use tokio::{
@@ -40,7 +39,36 @@ impl File {
         Ok(exists)
     }
 
-    async fn sha256_digest(&self) -> Result<String> {
+    pub async fn download(&self) -> Result<()> {
+        if self.is_downloaded().await? {
+            return Ok(());
+        }
+
+        let bucket = Bucket::new().map_err(|e| anyhow!("Failed to create bucket: {}", e))?;
+        bucket
+            .get_object_to_file(&self.object.key, &self.path)
+            .await?;
+
+        if !self.checksum_matches().await? {
+            log::error!(
+                "Checksum does not match {}, removing file!",
+                self.path.to_string_lossy()
+            );
+            fs::remove_file(&self.path).await?;
+        };
+        Ok(())
+    }
+
+    async fn checksum_matches(&self) -> Result<bool> {
+        let bucket = Bucket::new().map_err(|e| anyhow!("Failed to create bucket: {}", e))?;
+        let bucket_sha_string = bucket.read_object(&self.checksum.key).await?;
+        let bucket_sha = bucket_sha_string.split(' ').next().unwrap().to_lowercase();
+        let disk_sha = self.sha256_digest_lower().await?;
+        Ok(bucket_sha.eq(disk_sha.as_str()))
+    }
+
+    async fn sha256_digest_lower(&self) -> Result<String> {
+        // TODO: Refactor to utilities
         let input = fs::File::open(&self.path).await?;
         let mut reader = BufReader::new(input);
 
@@ -57,27 +85,5 @@ impl File {
             hasher.finalize()
         };
         Ok(format!("{:X}", digest))
-    }
-
-    pub async fn download(&self) -> Result<()> {
-        if self.is_downloaded().await? {
-            return Ok(());
-        }
-
-        let bucket = Bucket::new().map_err(|e| anyhow!("Failed to create bucket: {}", e))?;
-        bucket
-            .get_object_to_file(&self.object.key, &self.path)
-            .await?;
-
-        // TODO: add CHECKSUM check
-        info!(
-            "Calculated [{}] {:?}",
-            self.path.to_string_lossy(),
-            self.sha256_digest().await.unwrap()
-        );
-        let bucket_sha = bucket.bucket.get_object(&self.checksum.key).await?;
-        let bucket_sha = bucket_sha.as_str().unwrap().split(' ').next().unwrap();
-        info!("Read [{}] {:?}", self.checksum.key, bucket_sha);
-        Ok(())
     }
 }

--- a/src/data/binance/s3.rs
+++ b/src/data/binance/s3.rs
@@ -8,7 +8,7 @@ use tokio::fs;
 use crate::utils::config;
 
 pub struct Bucket {
-    pub bucket: S3Bucket,
+    bucket: S3Bucket,
 }
 
 impl Bucket {
@@ -61,5 +61,9 @@ impl Bucket {
             .flat_map(|result| result.contents)
             .collect::<Vec<Object>>();
         Ok(objects)
+    }
+
+    pub async fn read_object(&self, path: &str) -> Result<String> {
+        Ok(self.bucket.get_object(&path).await?.to_string()?)
     }
 }

--- a/src/data/binance/s3.rs
+++ b/src/data/binance/s3.rs
@@ -8,7 +8,7 @@ use tokio::fs;
 use crate::utils::config;
 
 pub struct Bucket {
-    bucket: S3Bucket,
+    pub bucket: S3Bucket,
 }
 
 impl Bucket {


### PR DESCRIPTION
### **PR Type**
Enhancement, Other


___

### **Description**
- Added SHA-256 checksum calculation for downloaded files in `src/data/binance/file.rs`.
- Introduced logging for checksum calculation and comparison in `src/data/binance/file.rs`.
- Implemented `sha256_digest` function to compute file checksum in `src/data/binance/file.rs`.
- Made `bucket` field public in `Bucket` struct in `src/data/binance/s3.rs`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file.rs</strong><dd><code>Add SHA-256 checksum calculation and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/binance/file.rs

<li>Added SHA-256 checksum calculation for downloaded files.<br> <li> Introduced logging for checksum calculation and comparison.<br> <li> Implemented <code>sha256_digest</code> function to compute file checksum.<br>


</details>


  </td>
  <td><a href="https://github.com/pashashocky/cryptoquant-rust/pull/14/files#diff-cb2cba86323f85da51a4a567ff227d401c13459ce9f01694e115c73e671b05e3">+33/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3.rs</strong><dd><code>Make `bucket` field public in `Bucket` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/binance/s3.rs

- Made `bucket` field in `Bucket` struct public.



</details>


  </td>
  <td><a href="https://github.com/pashashocky/cryptoquant-rust/pull/14/files#diff-936b1fe885588f754a485cd565b07f59f4c4172aff7d3a5f43fe93c668403ca2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

