### PR TITLE
fix(binance): filtering

### DIFF
--- a/src/data/binance/downloader.rs
+++ b/src/data/binance/downloader.rs
@@ -75,6 +75,8 @@ impl Downloader {
         let mut pairs = self.bucket.list_pairs(&path).await?;
 
         pairs.retain(|p| {
+            let mut has_filters = false;
+
             if let Some(excluded_filters) = &self.pair_filter_excluded {
                 if excluded_filters.iter().any(|f| p.name.contains(f)) {
                     return false;
@@ -82,18 +84,22 @@ impl Downloader {
             }
 
             if let Some(starts_with_filters) = &self.pair_filter_starts_with {
+                has_filters = true;
                 if starts_with_filters.iter().any(|f| p.name.starts_with(f)) {
                     return true;
                 }
             }
 
             if let Some(ends_with_filters) = &self.pair_filter_ends_with {
+                has_filters = true;
                 if ends_with_filters.iter().any(|f| p.name.ends_with(f)) {
                     return true;
                 }
             }
 
-            false
+            // If we have filters, we want the default to exclude ==> false
+            // If no filters, we want the default to return all ==> true
+            !has_filters
         });
 
         log::info!("[{}] Found {} pairs to download.", self.name, pairs.len());

--- a/src/data/binance/file_collection.rs
+++ b/src/data/binance/file_collection.rs
@@ -97,3 +97,10 @@ impl FromIterator<FileCollection> for FileCollection {
         FileCollection::new(files)
     }
 }
+
+impl FromIterator<File> for FileCollection {
+    fn from_iter<T: IntoIterator<Item = File>>(iter: T) -> Self {
+        let files: Vec<File> = iter.into_iter().collect();
+        FileCollection::new(files)
+    }
+}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed and enhanced the filtering logic in the Binance downloader to handle cases where no filters are provided.
- Introduced a `has_filters` flag to determine the default behavior when no filters are specified.
- Implemented `FromIterator<File>` for `FileCollection` to allow creating a `FileCollection` from an iterator of `File`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>downloader.rs</strong><dd><code>Fix and enhance filtering logic in Binance downloader</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/binance/downloader.rs

<li>Added logic to handle cases where no filters are provided.<br> <li> Introduced <code>has_filters</code> flag to determine default behavior.<br> <li> Modified filter logic to retain pairs based on new conditions.<br>


</details>


  </td>
  <td><a href="https://github.com/pashashocky/cryptoquant-rust/pull/18/files#diff-5d646d5b782b28efc2c78e249f2269a9d9b3226d8f2528e471625820c5135e41">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_collection.rs</strong><dd><code>Add FromIterator implementation for FileCollection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/binance/file_collection.rs

<li>Implemented <code>FromIterator<File></code> for <code>FileCollection</code>.<br> <li> Added method to create <code>FileCollection</code> from an iterator of <code>File</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/pashashocky/cryptoquant-rust/pull/18/files#diff-a6620d98d6b4a314d894869893b0c79214f02a09572a780fafaa6ad4006e4a47">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

