### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new Express server in `server.js` to handle HTTP requests.
- Added a `/feed` endpoint that returns a static JSON array representing an activity feed.
- Included sample data for the activity feed to demonstrate the API functionality.
- Set up the server to listen on port 3000 and log a message when running.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Implement Express server with activity feed endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphite-demo/server.js

<li>Added a new Express server setup.<br> <li> Implemented a GET endpoint <code>/feed</code> to return a static activity feed.<br> <li> Included sample activity feed data.<br> <li> Configured the server to listen on port 3000.<br>


</details>


  </td>
  <td><a href="https://github.com/pashashocky/cryptoquant-rust/pull/25/files#diff-d5c3b928f53ccb3225ebe5a3d21d3f7bd256109576695e5eb29abcf0419d1865">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

